### PR TITLE
V9.0.0/net9rc1 support

### DIFF
--- a/.docfx/index.md
+++ b/.docfx/index.md
@@ -8,7 +8,7 @@ title: Extensions for Asp.Versioning by Codebelt
 
 Originally, this project was part of **Cuemon for .NET**, but with the forthcoming release of .NET 9, it was split into its own project.
 
-This project is now part of [Extensions for Asp.Versioning by Codebelt](https://github.com/codebeltnet/asp-versioning).
+This project is now part of [Extensions for Asp.Versioning API by Codebelt](https://github.com/codebeltnet/asp-versioning).
 
 [Cuemon for .NET](https://www.cuemon.net/) will pursue its original purpose; providing an addition/complement/sidecar to Microsoft .NET platform.
 

--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -1,12 +1,12 @@
 name: Asp.Versioning Ext. CI/CD Pipeline
 on:
   pull_request:
-    branches: [main]
     paths-ignore:
       - .codecov
       - .docfx
       - .github
       - .nuget
+      - '**.md' 
   workflow_dispatch:
     inputs:
       configuration:
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         configuration: [Debug, Release]
-        framework: [net8.0,net6.0]
+        framework: [net9.0,net8.0]
     outputs:
       version: ${{ steps.minver-calculate.outputs.version }}
     steps:

--- a/.nuget/Codebelt.Extensions.Asp.Versioning/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Asp.Versioning/PackageReleaseNotes.txt
@@ -1,4 +1,11 @@
-﻿Version 8.4.0
+﻿Version 9.0.0
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+- REMOVED Support for TFM .NET 6 (LTS)
+ 
+Version 8.4.0
 Availability: .NET 8 and .NET 6
  
 # ALM

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsTestProject)' == 'false'">
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <Copyright>Copyright © Geekle 2024. All rights reserved.</Copyright>
     <Authors>gimlichael</Authors>
     <Company>Geekle</Company>
@@ -48,12 +48,8 @@
     <None Include="..\..\.nuget\$(MSBuildProjectName)\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(IsTestProject)' == 'true' AND '$(IsLinux)' == 'true'">
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(IsTestProject)' == 'true' AND '$(IsWindows)' == 'true'">
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+  <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
@@ -70,8 +66,8 @@
 
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.9.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.console" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageReference Include="coverlet.msbuild" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
@@ -81,7 +77,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Codebelt.Extensions.Xunit.App" Version="8.4.1" />
+    <PackageReference Include="Codebelt.Extensions.Xunit.App" Version="9.0.0-preview.4" />
   </ItemGroup>
 
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -14,8 +14,8 @@
 
   <Target Name="ApplyFileVersion" AfterTargets="MinVer">
     <PropertyGroup>
-      <BUILD_BUILDNUMBER Condition="'$(BUILD_BUILDNUMBER)' == ''">00000</BUILD_BUILDNUMBER>
-      <FileVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(BUILD_BUILDNUMBER)</FileVersion>
+      <GITHUB_RUN_NUMBER Condition="'$(GITHUB_RUN_NUMBER)' == ''">0</GITHUB_RUN_NUMBER>
+      <FileVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(GITHUB_RUN_NUMBER)</FileVersion>
     </PropertyGroup>
   </Target>
 </Project>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Asp.Versioning Ext. CI/CD Pipeline](https://github.com/codebeltnet/asp-versioning/actions/workflows/pipelines.yml/badge.svg)](https://github.com/codebeltnet/asp-versioning/actions/workflows/pipelines.yml) [![codecov](https://codecov.io/gh/codebeltnet/asp-versioning/graph/badge.svg?token=BN2UhFM3bb)](https://codecov.io/gh/codebeltnet/asp-versioning) [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=asp-versioning&metric=alert_status)](https://sonarcloud.io/dashboard?id=asp-versioning) [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=asp-versioning&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=asp-versioning) [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=asp-versioning&metric=reliability_rating)](https://sonarcloud.io/dashboard?id=asp-versioning) [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=asp-versioning&metric=security_rating)](https://sonarcloud.io/dashboard?id=asp-versioning)
 
-An open-source project (MIT license) that targets and complements the [asp-versioning](https://github.com/dotnet/aspnet-api-versioning) versioning engine. It aims to provide a uniform and convenient developer experience when working with RESTful API versioning.
+An open-source project (MIT license) that targets and complements the [Asp.Versioning](https://github.com/dotnet/aspnet-api-versioning) versioning engine. It aims to provide a uniform and convenient developer experience when working with RESTful API versioning.
 
 ### 📦 Standalone Packages
 

--- a/src/Codebelt.Extensions.Asp.Versioning/Codebelt.Extensions.Asp.Versioning.csproj
+++ b/src/Codebelt.Extensions.Asp.Versioning/Codebelt.Extensions.Asp.Versioning.csproj
@@ -9,23 +9,12 @@
     <PackageTags>extension-methods extensions restful-api-versioning versioning</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">
+  <ItemGroup>
     <PackageReference Include="Asp.Versioning.Abstractions" Version="8.1.0" />
     <PackageReference Include="Asp.Versioning.Http" Version="8.1.0" />
     <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0" />
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net6'))">
-    <PackageReference Include="Asp.Versioning.Abstractions" Version="6.2.1" />
-    <PackageReference Include="Asp.Versioning.Http" Version="6.5.0" />
-    <PackageReference Include="Asp.Versioning.Mvc" Version="6.4.1" />
-    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="6.4.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Cuemon.AspNetCore" Version="8.3.2" />
-    <PackageReference Include="Cuemon.Core" Version="8.3.2" />
+    <PackageReference Include="Cuemon.AspNetCore" Version="9.0.0-preview.9" />
   </ItemGroup>
 
 </Project>

--- a/test/Codebelt.Extensions.Asp.Versioning.Tests/ApiVersionReaderTest.cs
+++ b/test/Codebelt.Extensions.Asp.Versioning.Tests/ApiVersionReaderTest.cs
@@ -147,10 +147,12 @@ namespace Codebelt.Extensions.Asp.Versioning
                 Assert.EndsWith(jsonAccept, sut.Content.Headers.ContentType.ToString());
                 Assert.True(Match(@"{
   ""error"": {
+    ""instance"": ""http://localhost/fake/throw"",
     ""status"": 400,
     ""code"": ""BadRequest"",
     ""message"": ""The HTTP resource that matches the request URI \u0027http://localhost/fake/throw\u0027 does not support the API version \u0027d3\u0027.""
-  }
+  },
+  ""traceId"": ""*""
 }".ReplaceLineEndings(), (await sut.Content.ReadAsStringAsync()).ReplaceLineEndings()));
             }
         }
@@ -187,7 +189,7 @@ namespace Codebelt.Extensions.Asp.Versioning
                 Assert.Equal(HttpStatusCode.BadRequest, sut.StatusCode);
                 Assert.Equal(HttpMethod.Get, sut.RequestMessage.Method);
                 Assert.EndsWith(xmlAccept, sut.Content.Headers.ContentType.ToString());
-                Assert.True(Match(@"<?xml version=""1.0"" encoding=""utf-8""?><HttpExceptionDescriptor><Error><Status>400</Status><Code>BadRequest</Code><Message>The HTTP resource that matches the request URI 'http://localhost/fake/throw' does not support the API version 'd3'.</Message></Error></HttpExceptionDescriptor>", await sut.Content.ReadAsStringAsync()));
+                Assert.True(Match(@"<?xml version=""1.0"" encoding=""utf-8""?><HttpExceptionDescriptor><Error><Instance>http://localhost/fake/throw</Instance><Status>400</Status><Code>BadRequest</Code><Message>The HTTP resource that matches the request URI 'http://localhost/fake/throw' does not support the API version 'd3'.</Message></Error><TraceId>*</TraceId></HttpExceptionDescriptor>", await sut.Content.ReadAsStringAsync()));
             }
         }
 
@@ -270,6 +272,7 @@ namespace Codebelt.Extensions.Asp.Versioning
                 Assert.True(Match($$"""
                              {
                                "error": {
+                                 "instance": "http://localhost/fake/throw",
                                  "status": 400,
                                  "code": "BadRequest",
                                  "message": "The HTTP resource that matches the request URI 'http://localhost/fake/throw' does not support the API version 'd3'."
@@ -295,7 +298,8 @@ namespace Codebelt.Extensions.Asp.Versioning
                                    "cookies": [],
                                    "body": ""
                                  }
-                               }
+                               },
+                               "traceId": "*"
                              }
                              """.ReplaceLineEndings(), (await sut.Content.ReadAsStringAsync()).ReplaceLineEndings()));
             }

--- a/test/Codebelt.Extensions.Asp.Versioning.Tests/Codebelt.Extensions.Asp.Versioning.Tests.csproj
+++ b/test/Codebelt.Extensions.Asp.Versioning.Tests/Codebelt.Extensions.Asp.Versioning.Tests.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cuemon.Extensions.AspNetCore.Mvc" Version="8.3.2" />
-    <PackageReference Include="Cuemon.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json" Version="8.3.2" />
-    <PackageReference Include="Cuemon.Extensions.AspNetCore.Mvc.Formatters.Text.Json" Version="8.3.2" />
-    <PackageReference Include="Cuemon.Extensions.AspNetCore.Mvc.Formatters.Xml" Version="8.3.2" />
-    <PackageReference Include="Codebelt.Extensions.AspNetCore.Mvc.Formatters.Text.Yaml" Version="8.4.0" />
+    <PackageReference Include="Cuemon.Extensions.AspNetCore.Mvc" Version="9.0.0-preview.9" />
+    <PackageReference Include="Cuemon.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json" Version="9.0.0-preview.7" />
+    <PackageReference Include="Cuemon.Extensions.AspNetCore.Mvc.Formatters.Text.Json" Version="9.0.0-preview.9" />
+    <PackageReference Include="Cuemon.Extensions.AspNetCore.Mvc.Formatters.Xml" Version="9.0.0-preview.9" />
+    <PackageReference Include="Codebelt.Extensions.AspNetCore.Mvc.Formatters.Text.Yaml" Version="9.0.0-preview.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Codebelt.Extensions.Asp.Versioning.Tests/ProblemDetailsFactoryTest.cs
+++ b/test/Codebelt.Extensions.Asp.Versioning.Tests/ProblemDetailsFactoryTest.cs
@@ -105,7 +105,7 @@ namespace Codebelt.Extensions.Asp.Versioning
                 Assert.Equal(HttpStatusCode.BadRequest, sut.StatusCode);
                 Assert.Equal(HttpMethod.Get, sut.RequestMessage.Method);
                 Assert.EndsWith("application/xml", sut.Content.Headers.ContentType.ToString());
-                Assert.True(Match(@"<?xml version=""1.0"" encoding=""utf-8""?><HttpExceptionDescriptor><Error><Status>400</Status><Code>BadRequest</Code><Message>The HTTP resource that matches the request URI 'http://localhost/fake/throw' does not support the API version 'b3'.</Message></Error></HttpExceptionDescriptor>", await sut.Content.ReadAsStringAsync()));
+                Assert.True(Match(@"<?xml version=""1.0"" encoding=""utf-8""?><HttpExceptionDescriptor><Error><Instance>http://localhost/fake/throw</Instance><Status>400</Status><Code>BadRequest</Code><Message>The HTTP resource that matches the request URI 'http://localhost/fake/throw' does not support the API version 'b3'.</Message></Error><TraceId>*</TraceId></HttpExceptionDescriptor>", await sut.Content.ReadAsStringAsync()));
             }
         }
 
@@ -143,10 +143,12 @@ namespace Codebelt.Extensions.Asp.Versioning
                 Assert.True(Match("""
                                   {
                                     "error": {
+                                      "instance": "http://localhost/fake/throw",
                                       "status": 400,
                                       "code": "BadRequest",
                                       "message": "The HTTP resource that matches the request URI \u0027http://localhost/fake/throw\u0027 does not support the API version \u0027b3\u0027."
-                                    }
+                                    },
+                                    "traceId": "*"
                                   }
                                   """.ReplaceLineEndings(), (await sut.Content.ReadAsStringAsync())));
             }

--- a/testenvironments.json
+++ b/testenvironments.json
@@ -9,7 +9,7 @@
         {
             "name": "Docker-Ubuntu",
             "type": "docker",
-            "dockerImage": "gimlichael/ubuntu-testrunner:net6.0.424-net8.0.303"
+            "dockerImage": "gimlichael/ubuntu-testrunner:net6.0.425-net8.0.401-9.0.100-rc.1.24452.12"
         }
     ]
 }


### PR DESCRIPTION
#### PR Classification
Update to support .NET 9 and remove .NET 6.

#### PR Summary
Updated project to support .NET 9, removed .NET 6, and made documentation and dependency updates.
- `index.md` and `README.md`: Updated project title and description,
- `pipelines.yml`: Modified to ignore markdown changes and update target frameworks,
- `Directory.Build.props` and `Codebelt.Extensions.Asp.Versioning.csproj`: Updated target frameworks and package references,
- `ApiVersionReaderTest.cs` and `ProblemDetailsFactoryTest.cs`: Added new fields in error responses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Updated project title for clarity: "Extensions for Asp.Versioning API by Codebelt."
  - Enhanced error responses with additional detail (instance and traceId fields) for unsupported API versions.

- **Bug Fixes**
  - Corrected casing in project name within the README for consistency.

- **Documentation**
  - Updated release notes to reflect version changes and support for .NET 9.

- **Chores**
  - Updated dependencies and target frameworks across various project files, removing support for .NET 6.
  - Updated Docker image version for testing environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->