### PR TITLE
V9.0.0/rtm

### DIFF
--- a/.docfx/includes/availability-default.md
+++ b/.docfx/includes/availability-default.md
@@ -1,1 +1,1 @@
-Availability: .NET 8, .NET 6 and .NET Standard 2.0
+Availability: .NET 9, .NET 8 and .NET Standard 2.0

--- a/.docfx/includes/availability-modern.md
+++ b/.docfx/includes/availability-modern.md
@@ -1,1 +1,1 @@
-Availability: .NET 8 and .NET 6
+Availability: .NET 9 and .NET 8

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,13 +7,13 @@
     <PackageVersion Include="Asp.Versioning.Http" Version="8.1.0" />
     <PackageVersion Include="Asp.Versioning.Mvc" Version="8.1.0" />
     <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
-    <PackageVersion Include="Codebelt.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json" Version="9.0.0-rc.1" />
-    <PackageVersion Include="Codebelt.Extensions.AspNetCore.Mvc.Formatters.Text.Yaml" Version="9.0.0-rc.1" />
-    <PackageVersion Include="Codebelt.Extensions.Xunit.App" Version="9.0.0-rc.1" />
-    <PackageVersion Include="Cuemon.AspNetCore" Version="9.0.0-rc.1" />
-    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Mvc" Version="9.0.0-rc.1" />
-    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Mvc.Formatters.Text.Json" Version="9.0.0-rc.1" />
-    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Mvc.Formatters.Xml" Version="9.0.0-rc.1" />
+    <PackageVersion Include="Codebelt.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json" Version="9.0.0" />
+    <PackageVersion Include="Codebelt.Extensions.AspNetCore.Mvc.Formatters.Text.Yaml" Version="9.0.0" />
+    <PackageVersion Include="Codebelt.Extensions.Xunit.App" Version="9.0.0" />
+    <PackageVersion Include="Cuemon.AspNetCore" Version="9.0.0" />
+    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Mvc" Version="9.0.0" />
+    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Mvc.Formatters.Text.Json" Version="9.0.0" />
+    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Mvc.Formatters.Xml" Version="9.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="MinVer" Version="6.0.0" />

--- a/testenvironments.json
+++ b/testenvironments.json
@@ -9,7 +9,7 @@
         {
             "name": "Docker-Ubuntu",
             "type": "docker",
-            "dockerImage": "gimlichael/ubuntu-testrunner:6.0.427-net8.0.403-9.0.100-rc.2.24474.11"
+            "dockerImage": "gimlichael/ubuntu-testrunner:net8.0.404-9.0.100"
         }
     ]
 }


### PR DESCRIPTION
This pull request includes updates to the availability documentation, package versions, and test environment configurations. The most important changes are:

### Documentation Updates:
* Updated the availability information to include .NET 9 in both `.docfx/includes/availability-default.md` and `.docfx/includes/availability-modern.md`. [[1]](diffhunk://#diff-e7c6e56f92f2e9152c615f69aeb95db756fc7be579eacb9672a51ce58056b39aL1-R1) [[2]](diffhunk://#diff-95558ec93b4ec78af969c1b9e8e996f17ebdfa5f4b3517b744884f00ecdb78e6L1-R1)

### Package Version Updates:
* Updated several package versions from release candidates (rc.1) to stable versions (9.0.0) in `Directory.Packages.props`.

### Test Environment Configuration:
* Updated the Docker image for the `Docker-Ubuntu` test environment in `testenvironments.json` to use the latest version tags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated availability information to support .NET 9 alongside .NET 8 and .NET Standard 2.0.
  
- **Bug Fixes**
	- Removed outdated references to .NET 6 in availability sections.

- **Chores**
	- Updated package dependencies to stable version 9.0.0.
	- Simplified versioning in Docker environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->