### PR TITLE
V9.0.2/bump

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="Asp.Versioning.Http" Version="8.1.0" />
     <PackageVersion Include="Asp.Versioning.Mvc" Version="8.1.0" />
     <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
-    <PackageVersion Include="Codebelt.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json" Version="9.0.1" />
+    <PackageVersion Include="Codebelt.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json" Version="9.0.2" />
     <PackageVersion Include="Codebelt.Extensions.AspNetCore.Mvc.Formatters.Text.Yaml" Version="9.0.2" />
     <PackageVersion Include="Codebelt.Extensions.Xunit.App" Version="10.0.0" />
     <PackageVersion Include="Cuemon.AspNetCore" Version="9.0.4" />


### PR DESCRIPTION
This pull request includes a minor version update for the `Codebelt.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json` package in the `Directory.Packages.props` file. The package version has been updated from 9.0.1 to 9.0.2.

* [`Directory.Packages.props`](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L10-R10): Updated the `Codebelt.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json` package version from 9.0.1 to 9.0.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the version of a backend package dependency to improve stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->