### PR TITLE
V9.0.6/service update

### DIFF
--- a/.nuget/Codebelt.Extensions.Asp.Versioning/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Asp.Versioning/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.5
+﻿Version 9.0.6
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+Version 9.0.5
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ For more details, please refer to `PackageReleaseNotes.txt` on a per assembly ba
 > [!NOTE]  
 > Changelog entries prior to version 8.4.0 was migrated from previous versions of Cuemon.Extensions.Asp.Versioning.
 
+## [9.0.6] - 2025-08-20
+
+This is a service update that focuses on package dependencies.
+
 ## [9.0.5] - 2025-07-11
 
 This is a service update that focuses on package dependencies.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,19 +7,19 @@
     <PackageVersion Include="Asp.Versioning.Http" Version="8.1.0" />
     <PackageVersion Include="Asp.Versioning.Mvc" Version="8.1.0" />
     <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
-    <PackageVersion Include="Codebelt.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json" Version="9.0.5" />
-    <PackageVersion Include="Codebelt.Extensions.AspNetCore.Mvc.Formatters.Text.Yaml" Version="9.0.5" />
-    <PackageVersion Include="Codebelt.Extensions.Xunit.App" Version="10.0.4" />
-    <PackageVersion Include="Cuemon.AspNetCore" Version="9.0.7" />
-    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Mvc" Version="9.0.7" />
-    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Mvc.Formatters.Text.Json" Version="9.0.7" />
-    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Mvc.Formatters.Xml" Version="9.0.7" />
+    <PackageVersion Include="Codebelt.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json" Version="9.0.6" />
+    <PackageVersion Include="Codebelt.Extensions.AspNetCore.Mvc.Formatters.Text.Yaml" Version="9.0.6" />
+    <PackageVersion Include="Codebelt.Extensions.Xunit.App" Version="10.0.5" />
+    <PackageVersion Include="Cuemon.AspNetCore" Version="9.0.8" />
+    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Mvc" Version="9.0.8" />
+    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Mvc.Formatters.Text.Json" Version="9.0.8" />
+    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Mvc.Formatters.Xml" Version="9.0.8" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.console" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>
 </Project>

--- a/testenvironments.json
+++ b/testenvironments.json
@@ -9,7 +9,7 @@
         {
             "name": "Docker-Ubuntu",
             "type": "docker",
-            "dockerImage": "gimlichael/ubuntu-testrunner:net8.0.412-9.0.302"
+            "dockerImage": "gimlichael/ubuntu-testrunner:net8.0.413-9.0.304"
         }
     ]
 }


### PR DESCRIPTION
This pull request is a service update focused on keeping the project up-to-date with the latest compatible dependencies. It updates several NuGet package versions, refreshes the Docker test environment image, and documents these changes in the release notes and changelog.

Dependency updates:

* Updated several NuGet package dependencies in `Directory.Packages.props` to their latest compatible versions, including `Codebelt.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json`, `Codebelt.Extensions.AspNetCore.Mvc.Formatters.Text.Yaml`, `Codebelt.Extensions.Xunit.App`, and multiple `Cuemon` packages. Also updated `xunit.runner.visualstudio` to version 3.1.4.

Test environment maintenance:

* Updated the Docker image used for the "Docker-Ubuntu" test environment in `testenvironments.json` to a newer version (`gimlichael/ubuntu-testrunner:net8.0.413-9.0.304`).

Documentation:

* Added release notes for version 9.0.6 in `.nuget/Codebelt.Extensions.Asp.Versioning/PackageReleaseNotes.txt`, noting the dependency upgrades and continued support for .NET 8 and 9.
* Added a changelog entry for version 9.0.6 in `CHANGELOG.md`, summarizing the update as focusing on package dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded package dependencies to latest compatible versions for .NET 9 and .NET 8.
  * Bumped centralized package versions (ASP.NET Core formatters, Cuemon libraries, test utilities, xUnit runner).
  * Updated Docker Ubuntu test environment image to newer .NET SDK/runtime patch.

* **Documentation**
  * Added release notes and changelog entry for version 9.0.6, highlighting a dependency-focused service update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->