### PR TITLE
V9.0.8/service update

### DIFF
--- a/.nuget/Codebelt.Extensions.Asp.Versioning/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Asp.Versioning/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.7
+﻿Version 9.0.8
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+Version 9.0.7
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ For more details, please refer to `PackageReleaseNotes.txt` on a per assembly ba
 > [!NOTE]  
 > Changelog entries prior to version 8.4.0 was migrated from previous versions of Cuemon.Extensions.Asp.Versioning.
 
+## [9.0.8] - 2025-10-20
+
+This is a service update that focuses on package dependencies.
+
 ## [9.0.7] - 2025-09-15
 
 This is a service update that focuses on package dependencies.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,19 +7,19 @@
     <PackageVersion Include="Asp.Versioning.Http" Version="8.1.0" />
     <PackageVersion Include="Asp.Versioning.Mvc" Version="8.1.0" />
     <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
-    <PackageVersion Include="Codebelt.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json" Version="9.0.7" />
-    <PackageVersion Include="Codebelt.Extensions.AspNetCore.Mvc.Formatters.Text.Yaml" Version="9.0.7" />
-    <PackageVersion Include="Codebelt.Extensions.Xunit.App" Version="10.0.6" />
-    <PackageVersion Include="Cuemon.AspNetCore" Version="9.0.9" />
-    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Mvc" Version="9.0.9" />
-    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Mvc.Formatters.Text.Json" Version="9.0.9" />
-    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Mvc.Formatters.Xml" Version="9.0.9" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="Codebelt.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json" Version="9.0.8" />
+    <PackageVersion Include="Codebelt.Extensions.AspNetCore.Mvc.Formatters.Text.Yaml" Version="9.0.8" />
+    <PackageVersion Include="Codebelt.Extensions.Xunit.App" Version="10.0.7" />
+    <PackageVersion Include="Cuemon.AspNetCore" Version="9.0.10" />
+    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Mvc" Version="9.0.10" />
+    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Mvc.Formatters.Text.Json" Version="9.0.10" />
+    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Mvc.Formatters.Xml" Version="9.0.10" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.console" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 </Project>

--- a/testenvironments.json
+++ b/testenvironments.json
@@ -9,7 +9,7 @@
         {
             "name": "Docker-Ubuntu",
             "type": "docker",
-            "dockerImage": "gimlichael/ubuntu-testrunner:net8.0.414-9.0.305"
+            "dockerImage": "gimlichael/ubuntu-testrunner:net8.0.415-9.0.306"
         }
     ]
 }


### PR DESCRIPTION
This pull request is a service update focused on keeping package dependencies up to date across the repository. The main changes include updating dependency versions for several packages, updating the test environment Docker image, and documenting these updates in the changelog and release notes.

**Dependency Updates:**

* Updated several package dependencies to their latest compatible versions in `Directory.Packages.props`, including `Codebelt.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json`, `Codebelt.Extensions.AspNetCore.Mvc.Formatters.Text.Yaml`, `Codebelt.Extensions.Xunit.App`, `Cuemon.AspNetCore`, `Cuemon.Extensions.AspNetCore.Mvc`, `Cuemon.Extensions.AspNetCore.Mvc.Formatters.Text.Json`, `Cuemon.Extensions.AspNetCore.Mvc.Formatters.Xml`, `Microsoft.NET.Test.Sdk`, and `xunit.runner.visualstudio`.

**Test Environment:**

* Updated the Docker test runner image in `testenvironments.json` to use a newer version (`net8.0.415-9.0.306`).

**Documentation:**

* Added release notes for version 9.0.8 in `.nuget/Codebelt.Extensions.Asp.Versioning/PackageReleaseNotes.txt`, noting upgraded dependencies for all supported target frameworks.
* Added a new changelog entry for version 9.0.8 in `CHANGELOG.md`, describing it as a service update focused on package dependencies.